### PR TITLE
Fix to allow node modules to import the esm module correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,18 @@
 {
   "name": "remark-obsidian",
   "version": "1.3.0",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "files": [
-    "dist/cjs/index.js",
-    "dist/esm/index.js"
+    "dist/cjs/index.cjs",
+    "dist/esm/index.mjs"
   ],
+  "exports": {
+    ".": {
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs"
+    }
+  },
   "scripts": {
     "test": "jest",
     "deploy": "CI=true npx semantic-release",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,8 +6,8 @@ import { terser } from 'rollup-plugin-terser';
 export default {
     input: 'src/index.js',
     output: [
-        { format: 'esm', file: 'dist/esm/index.js' },
-        { format: 'cjs', file: 'dist/cjs/index.js', exports: 'named' },
+        { format: 'esm', file: 'dist/esm/index.mjs' },
+        { format: 'cjs', file: 'dist/cjs/index.cjs', exports: 'named' },
     ],
     plugins: [
         nodeResolve(),


### PR DESCRIPTION
## Use case:

**index.mjs**
```javascript
import { remark } from 'remark';
import plugin from 'remark-obsidian';

const text = '**markdown text** with [[Internal link]]';
const output = String(await remark().use(plugin).process(text));

console.log(output);
console.log(Object.keys(plugin));
```

## Desired output:

```sh
$ node index.mjs 
<p><strong>markdown text</strong> with <a href="/internal-link" title="Internal link">Internal link</a></p>

[]
```

The esm module is imported and remarkObsidian is the default exported function.

## Observed output:

```sh
$ node index.mjs 
**markdown text** with \[\[Internal link]]

[ 'default', 'parseBracketLink' ]
```

The cjs module is imported and remarkObsidian.default is the default exported function.